### PR TITLE
[vote] Update governance to add contributor ladder and steering committee

### DIFF
--- a/contributor_ladder.md
+++ b/contributor_ladder.md
@@ -1,0 +1,221 @@
+# Contributor Ladder
+
+Hello! We are excited that you want to learn more about our project contributor
+ladder! This contributor ladder outlines the different contributor roles within
+the project, along with the responsibilities and privileges that come with them.
+Community members generally start at the first levels of the ladder and advance
+up it as their involvement in the project grows.  Our project members are happy
+to help you advance along the contributor ladder.
+
+Each of the contributor roles below is organized into lists of three types of
+things. "Responsibilities" are things that a contributor is expected to do.
+"Requirements" are qualifications a person needs to meet to be in that role, and
+"Privileges" are things contributors on that level are entitled to.
+
+While privileges are outlined here, the exact mapping of these privileges to
+physical permissions within a repository is left to the maintainers for that
+repository, as each repository has different code review and CI/CD workflows
+with different considerations.
+
+The authoritative source for contributor status will be the following files housed in this repository:
+
+- [`contributors/organization_members.md`](contributors/organization_members.md)
+- [`contributors/core_contributors.md`](contributors/core_contributors.md)
+- [`contributors/maintainers.md`](contributors/maintainers.md)
+
+Contributor Ladder status _may_ also be tracked in individual project
+repositories (e.g. Golang maintainers in the [grpc-go
+repo](https://github.com/grpc/grpc-go)), but these listings will not be
+authoritative.
+
+
+## Organization Member
+
+[**Current Organization Members**](contributors/organization_members.md)
+
+Description: An Organization Member (or Org Member) is an established
+contributor who regularly participates in the project. 
+
+#### Delegation to an Organization Member
+
+Individual PR reviews and issues are delegated to Organization Members by
+[Core Contributors](#core-contributor) or [Maintainers](#maintainer) explicitly, via
+written communication. When a Core Contributor or Maintainer delegates a review or
+issue to an Organization Member, it is the responsibility of the delegator to
+do initial triage of the PR or issue and ensure that it generally makes sense
+and is appropriate for this repository. In addition, the delegator should
+provide oversight to the Organization Member, ensuring quality.
+
+In other words, it is not expected that an Organization Member will be the
+_sole_ reviewer of a PR, but will be able to help with initial passes.
+
+#### Rights and Responsibilities
+
+An Organization Member:
+
+* Responsibilities:
+    * Continues to contribute regularly, as demonstrated by having at least 4 accepted pull requests or resolved issues per year
+* Requirements to become an Organization Member:
+    * Must have successful contributions to the project, including at least one of the following:
+        * 4 accepted PRs,
+        * Successfully reviewed 4 PRs (as assessed by a maintainer for the relevant repository)
+        * Resolved and closed 4 Issues
+        * Become responsible for a key project management area,
+        * Or some equivalent combination or contribution
+    * Must be actively contributing to at least one project area
+    * Must have two sponsors who are also Organization Members or higher, who indicate their support via the PR process outlined below.
+
+* Privileges:
+    * May be delegated Issues and Reviews by a Core Contributor or Maintainer
+    * May give commands to CI/CD automation as interpreted by the relevant repository's maintainers
+    * Can recommend other contributors to become Org Members
+
+
+The process for a contributor to become an Organization Member is as follows:
+
+The official list of Org Members is kept up to date
+[here](contributors/organization_members.md). Anyone may create a PR to propose
+the addition of a new Organization Member. The PR must have the approval of two
+existing Organization Members (or higher). If the author of the PR is not the
+nominee, then the nominee must comment on the PR indicating their support for
+the new role and its responsibilities. If all of the above conditions are met,
+the PR must be merged.
+
+### Core Contributor
+
+[**Current Core Contributors**](contributors/core_contributors.md)
+
+Description: A Core Contributor has responsibility for specific code, documentation,
+test, or other project areas. They are collectively responsible, with other
+Core Contributors and Maintainers, for reviewing all changes to those areas and
+indicating whether those changes are ready to merge. They have a track record
+of contribution and review in the project.
+
+[Maintainers](#maintainers)
+maintain overall control for a gRPC subproject (such as an implementation in a
+particular language), but delegate authority for a specific subdomain to one or
+more gRPC Project Core Contributors.
+
+Core Contributors are responsible for a "specific area." This can be a specific
+repository, code directory, chapter of the docs, test job, event, or other
+clearly-defined project. The "specific area" below refers to this area of
+responsibility.
+
+#### Delegation to a Core Contributor
+
+Individual PR reviews and issues are delegated to Core Contributors by Maintainers
+either implicitly (via prior verbal agreement on repository policy) or
+explicitly, via written communication. When a Maintainer delegates a review or
+issue to a Core Contributor, it is the responsibility of that Maintainer to do initial
+triage of the PR or issue and ensure that it generally makes sense and is
+appropriate for this repository, and that the Core Contributor to which it is
+delegated is the appropriate person to look into the details.
+
+Put informally, the delegating Maintainer must still provide "approval" but not
+necessarily "LGTM," which is left to the Core Contributor.
+
+#### Rights and Responsibilities
+
+Core Contributors have all the rights and responsibilities of an Organization Member, plus:
+
+* Responsibilities:
+    * Reviewing most Pull Requests against their specific areas of responsibility
+    * Helping other contributors become Core Contributors
+* Requirements to become a Core Contributor:
+    * Is already an Organization Member
+    * Has demonstrated an in-depth knowledge of the specific area
+    * Commits to being responsible for that specific area
+    * Is supportive of new and occasional contributors and helps get useful PRs in shape to commit
+    * Must have two sponsors who are Core Contributors or higher within the relevant repo(s), who indicate their support via the PR process outlined below.
+* Additional privileges:
+    * Has permissions to approve pull requests relating to their area of expertise
+    * Can recommend and review other contributors to become Core Contributors
+    
+The process of becoming a Core Contributor is as follows:
+
+The official list of Core Contributors is kept up to date
+[here](contributors/core_contributors.md). Anyone may create a PR to propose the
+addition of a new Core Contributor, specifically naming their area of expertise and
+which repositories it applies to. The approval of two existing Core Contributors
+(or higher) is required for merge. These two approvers must have standing
+within the relevant repository listed in the PR. If the author of the PR is not
+the nominee, then the nominee must comment on the PR indicating their support
+for the new role and its responsibilities. If all of the above conditions are
+met, then the PR must be approved.
+
+### Maintainer
+
+[**Current Maintainers**](contributors/maintainers.md)
+
+Description: Maintainers are very established contributors who are collectively
+responsible for the entire project and personally responsible for large
+subprojects. As such, they have broad voting powers, sole authority over their
+area of expertise, and are expected to participate in decision-making about the
+strategy and priorities of the project.
+
+A Maintainer must meet the responsibilities and requirements of a Core Contributor, plus:
+
+* Responsibilities include:
+    * Mentoring new Core Contributors and Organization Members
+    * Writing refactoring PRs
+    * Participating in CNCF maintainer activities
+    * Participating in, and leading, community meetings
+* Requirements to become a Maintainer:
+    * Is already a Core Contributor.
+    * Demonstrates a broad knowledge of the project across multiple areas
+    * Is able to exercise judgment for the good of the project, independent of their employer, friends, or team
+    * Mentors other contributors
+    * Can commit to spending at least 10 hours per month working on the project
+    * Majority vote of existing Maintainers.
+* Additional privileges:
+    * Approve PRs in their area of ownership with no oversight
+    * Represent the project in public as a Maintainer
+    * Communicate with the CNCF on behalf of the project
+    * Vote in Steering Committee Elections
+
+#### Collaboration between Maintainers
+
+Maintainers have broad authority over their area of expertise, as well as
+weighty influence in their voting powers. However, many changes
+will span multiple areas of expertise. While the [primary workflow for driving
+changes in the gRPC project requires the approval of only a single
+maintainer](governance.md#decision-making-and-voting), some changes will span
+_multiple_ areas of expertise. This is especially true for
+[gRFCs](governance.md#the-grfc-process). In this case, _one_ maintainer acts as
+the triager and is responsible for adding a maintainer to the review to
+represent all relevant areas of expertise. For example, a new load balancing
+policy proposed in a gRFC must be implementable in all supported languages, so a
+Maintainer for C++, Go, Java, etc. should be added to the review by the triaging
+Maintainer.
+
+Process of becoming a maintainer:
+1. Any current Maintainer may nominate a current Core Contributor to become a new Maintainer, by opening a PR to [maintainers.md](contributors/maintainers.md).
+2. The nominee will add a comment to the PR testifying that they agree to all requirements of becoming a Maintainer.
+3. A majority of the current Maintainers (as listed in [maintainers.md](contributors/maintainers.md)) must then approve the PR or give verbal approval in a meeting.
+
+
+## Inactivity
+It is important for contributors to remain active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a loss of trust in the project.
+
+* Inactivity is measured by:
+    * Periods of no contributions for longer than 6 months, including Github comments, PRs, and issues.
+    * Periods of no communication for longer than 6 months, including emails, messages, and attendance at project meetings.
+* Consequences of being inactive include:
+    * Involuntary removal or demotion
+    * Being asked to move to Emeritus status
+
+## Involuntary Removal or Demotion
+
+Involuntary removal/demotion of a contributor happens when responsibilities and requirements aren't being met. This may include repeated patterns of inactivity, extended period of inactivity, a period of failing to meet the requirements of your role, and/or a violation of the Code of Conduct. This process is important because it protects the community and its deliverables while also opening up opportunities for new contributors to step in.
+
+Involuntary removal or demotion is handled through a vote by a majority of the current Maintainers.
+
+## Stepping Down/Emeritus Process
+If and when contributors' commitment levels change, contributors can consider stepping down (moving down the contributor ladder) vs moving to emeritus status (completely stepping away from the project).
+
+Contact the Maintainers about changing to Emeritus status, or reducing your contributor level.
+
+Emeritus status is reflected by moving a contributor to the Emeritus table at the bottom of the official list for each ladder rung.
+
+## Contact
+For inquiries, please reach out to [grpc-steering@googlegroups.com](mailto:grpc-steering@googlegroups.com).

--- a/contributors/core_contributors.md
+++ b/contributors/core_contributors.md
@@ -10,7 +10,7 @@ Members as well.
 
 | Name | Github Handle | Area(s) of Expertise | Repo(s) | Employer | 
 |--|--|--|--|--|
-| AJ Heller | [drfloob](https://github.com/drfloob) | Core/C++, EventEngine | [grpc](https://github.com/grpc/grpc) | Google | 
+| Adam Heller | [drfloob](https://github.com/drfloob) | Core/C++, EventEngine | [grpc](https://github.com/grpc/grpc) | Google |
 | Akshit Patel | [ac-patel](https://github.com/ac-patel) | Core/C++ | [grpc](https://github.com/grpc/grpc) | Google |
 | Alex Polcyn | [apolcyn](https://github.com/apolcyn) | Ruby | [grpc](https://github.com/grpc/grpc) | Google | 
 | Alisha Nanda | [ananda1066](https://github.com/ananda1066) | Core/C++ | [grpc](https://github.com/grpc/grpc) | Google |

--- a/contributors/core_contributors.md
+++ b/contributors/core_contributors.md
@@ -1,0 +1,41 @@
+# Core Contributors
+
+
+This is the authoritative listing of
+[Core Contributors](../contributor_ladder.md#core_contributor) within the gRPC project,
+sorted alphabetically by first name. In addition to all of the individuals
+listed here, all [Maintainers](maintainers.md) are considered Organization
+Members as well.
+
+
+| Name | Github Handle | Area(s) of Expertise | Repo(s) | Employer | 
+|--|--|--|--|--|
+| AJ Heller | [drfloob](https://github.com/drfloob) | Core/C++, EventEngine | [grpc](https://github.com/grpc/grpc) | Google | 
+| Akshit Patel | [ac-patel](https://github.com/ac-patel) | Core/C++ | [grpc](https://github.com/grpc/grpc) | Google |
+| Alex Polcyn | [apolcyn](https://github.com/apolcyn) | Ruby | [grpc](https://github.com/grpc/grpc) | Google | 
+| Alisha Nanda | [ananda1066](https://github.com/ananda1066) | Core/C++ | [grpc](https://github.com/grpc/grpc) | Google |
+| Daniel Liu | [danielzhaotongliu](https://github.com/danielzhaotongliu) | Core/C++ | [grpc](https://github.com/grpc/grpc) | Google |
+| Easwar Swaminathan | [easwars](https://github.com/easwars) | xDS (Golang) | [grpc-go](https://github.com/grpc/grpc-go) | Google | 
+| Eryu Xia | [sampajano](https://github.com/sampajano) | iOS | [grpc](https://github.com/grpc/grpc) | Google | 
+| Gregory Cooke | [gtcooke94](https://github.com/gtcooke94) | Security (cross-language) | [grpc](https://github.com/grpc/grpc), [grpc-go](https://github.com/grpc/grpc-go), [grpc-java](https://github.com/grpc/grpc-java) | Google |
+| Gus Cairo | [gjcairo](https://github.com/gjcairo) | Swift | [grpc-swift](https://github.com/grpc/grpc-swift) | Apple |
+| Ivy (Yifei) Zhuang | [yifeizhuang](https://github.com/yifeizhuang) | Java | [grpc-java](https://github.com/grpc/grpc-java) | Google | 
+| Kannan Jayprakasam | [kannanjgithub](https://github.com/kannanjgithub) | Java, xDS Interop | [grpc-java](https://github.com/grpc/grpc-java), [psm-interop](https://github.com/grpc/psm-interop) | Google |
+| Lucio Franco | [LucioFranco](https://github.com/LucioFranco) | Rust | [hyperium/tonic](https://github.com/hyperium/tonic) | Turso | 
+| Luwei Ge | [rockspore](https://github.com/rockspore) | Security (cross-language) | [grpc](https://github.com/grpc/grpc), [grpc-go](https://github.com/grpc/grpc-go), [grpc-java](https://github.com/grpc/grpc-java) | Google |
+| Matthew Stevenson | [matthewstevenson88](https://github.com/matthewstevenson88) | Security (cross-language) | [grpc](https://github.com/grpc/grpc), [grpc-go](https://github.com/grpc/grpc-go), [grpc-java](https://github.com/grpc/grpc-java) | Google |
+| Patrice Chalin | [chalin](https://github.com/chalin) | grpc.io | [grpc.io](https://github.com/grpc/grpc.io) | CNCF |
+| Paulo Castello da Costa | [paulosjca](https://github.com/paulosjca) | Benchmarking | [test-infra](https://github.com/grpc/test-infra) | Google |
+| Sergii Tkachenko | [sergiitk](https://github.com/sergiitk) | Python, xDS Interop | [grpc](https://github.com/grpc/grpc), [psm-interop](https://github.com/grpc/psm-interop) | Google |
+| Stanley Cheung | [stanley-cheung](https://github.com/stanley-cheung) | PHP | [grpc](https://github.com/grpc/grpc) | Google | 
+| Terry Wilson | [temawi](https://github.com/temawi) | Android | [grpc-java](https://github.com/grpc/grpc-java) | Google | 
+| Tanvi Jagtap | [tanvi-jagtap](https://github.com/tanvi-jagtap) | Core/C++ | [grpc](https://github.com/grpc/grpc) | Google | 
+| Vignesh Babu | [vignesh2208](https://github.com/vignesh2208) | Core/C++ | [grpc](https://github.com/grpc/grpc)| Google |
+| Xuan Wang | [XuanWang-Amos](https://github.com/XuanWang-Amos) | Python | [grpc](https://github.com/grpc/grpc) | Google | 
+| Yash Tibrewal | [yashykt](https://github.com/yashykt) | Core/C++, Observability (cross-language) | [grpc](https://github.com/grpc/grpc) | Google | 
+| Yousuk Seung | [yousukseung](https://github.com/yousukseung) | Core/C++ | [grpc](https://github.com/grpc/grpc) | Google | 
+
+## Emeritus Core Contributors
+
+| Name | Github Handle | Area(s) of Expertise | Repo(s) | Employer | 
+|--|--|--|--|--|

--- a/contributors/core_contributors.md
+++ b/contributors/core_contributors.md
@@ -4,8 +4,8 @@
 This is the authoritative listing of
 [Core Contributors](../contributor_ladder.md#core_contributor) within the gRPC project,
 sorted alphabetically by first name. In addition to all of the individuals
-listed here, all [Maintainers](maintainers.md) are considered Organization
-Members as well.
+listed here, all [Maintainers](maintainers.md) are considered Core Contributors
+as well.
 
 
 | Name | Github Handle | Area(s) of Expertise | Repo(s) | Employer | 

--- a/contributors/core_contributors.md
+++ b/contributors/core_contributors.md
@@ -14,6 +14,7 @@ as well.
 | Akshit Patel | [ac-patel](https://github.com/ac-patel) | Core/C++ | [grpc](https://github.com/grpc/grpc) | Google |
 | Alex Polcyn | [apolcyn](https://github.com/apolcyn) | Ruby | [grpc](https://github.com/grpc/grpc) | Google | 
 | Alisha Nanda | [ananda1066](https://github.com/ananda1066) | Core/C++ | [grpc](https://github.com/grpc/grpc) | Google |
+| Arjan Bal | [arjan-bal](https://github.com/arjan-bal) | Go | [grpc-go](https://github.com/grpc/grpc-go) | Google |
 | Daniel Liu | [danielzhaotongliu](https://github.com/danielzhaotongliu) | Core/C++ | [grpc](https://github.com/grpc/grpc) | Google |
 | Easwar Swaminathan | [easwars](https://github.com/easwars) | xDS (Golang) | [grpc-go](https://github.com/grpc/grpc-go) | Google | 
 | Eryu Xia | [sampajano](https://github.com/sampajano) | iOS | [grpc](https://github.com/grpc/grpc) | Google | 
@@ -26,6 +27,7 @@ as well.
 | Matthew Stevenson | [matthewstevenson88](https://github.com/matthewstevenson88) | Security (cross-language) | [grpc](https://github.com/grpc/grpc), [grpc-go](https://github.com/grpc/grpc-go), [grpc-java](https://github.com/grpc/grpc-java) | Google |
 | Patrice Chalin | [chalin](https://github.com/chalin) | grpc.io | [grpc.io](https://github.com/grpc/grpc.io) | CNCF |
 | Paulo Castello da Costa | [paulosjca](https://github.com/paulosjca) | Benchmarking | [test-infra](https://github.com/grpc/test-infra) | Google |
+| Pawan Bhardwaj | [pawbhard](https://github.com/pawbhard) | Core/C++ | [grpc](https://github.com/grpc/grpc) | Google |
 | Sergii Tkachenko | [sergiitk](https://github.com/sergiitk) | Python, xDS Interop | [grpc](https://github.com/grpc/grpc), [psm-interop](https://github.com/grpc/psm-interop) | Google |
 | Stanley Cheung | [stanley-cheung](https://github.com/stanley-cheung) | PHP | [grpc](https://github.com/grpc/grpc) | Google | 
 | Terry Wilson | [temawi](https://github.com/temawi) | Android | [grpc-java](https://github.com/grpc/grpc-java) | Google | 

--- a/contributors/maintainers.md
+++ b/contributors/maintainers.md
@@ -1,0 +1,27 @@
+# Maintainers
+
+This is the authoritative listing of
+[Maintainers](../contributor_ladder.md#maintainer) within the gRPC project,
+sorted alphabetically by first name.
+
+
+| Name | Github Handle | Area(s) of Expertise | Repo(s) | Employer | 
+|--|--|--|--|--|
+| Antoine Tollenaere | [atollena](https://github.com/atollena) | Go | [grpc-go](https://github.com/grpc/grpc-go) | Datadog |
+| Craig Tiller | [ctiller](https://github.com/ctiller) | C++ | [grpc](https://github.com/grpc/grpc) | Google |
+| Doug Fawley | [dfawley](https://github.com/dfawley) | Go | [grpc-go](https://github.com/grpc/grpc-go) | Google |
+| Eric Anderson | [ejona86](https://github.com/ejona86) | Java | [grpc-java](https://github.com/grpc/grpc-java) | Google |
+| Esun Kim | [veblush](https://github.com/veblush) | C++ | [grpc](https://github.com/grpc/grpc) | Google |
+| George Barnett | [glbrntt](https://github.com/glbrntt) | Swift | [grpc-swift](https://github.com/grpc/grpc-swift) | Apple |
+| James Newton-King | [JamesNK](https://github.com/JamesNK) | .Net | [grpc-dotnet](https://github.com/grpc/grpc-dotnet) | Microsoft |
+| Jung-Yu (Gina) Yeh | [ginayeh](https://github.com/ginayeh) | Go | [grpc-go](https://github.com/grpc/grpc-go) | Google |
+| Kun Zhang | [zhangkun83](https://github.com/zhangkun83) | Java | [grpc-java](https://github.com/grpc/grpc-java) | Google |
+| Mark Roth | [markdroth](https://github.com/markdroth) | C++, xDS | [grpc](https://github.com/grpc/grpc) | Google |
+| Michael Lumish | [murgatroid99](https://github.com/murgatroid99) | Node.js | [grpc-node](https://github.com/grpc/grpc-node) | Google | 
+| Nupur Kothari | [nupurkot](https://github.com/nupurkot) | C++, Java, Python | [grpc](https://github.com/grpc/grpc), [grpc-java](https://github.com/grpc/grpc-java) | Google | 
+| Richard Belleville | [gnossen](https://github.com/gnossen) | Python | [grpc](https://github.com/grpc/grpc) | Google |
+
+## Emeritus Maintainers
+
+| Name | Github Handle | Area(s) of Expertise | Repo(s) | Employer | 
+|--|--|--|--|--|

--- a/contributors/maintainers.md
+++ b/contributors/maintainers.md
@@ -11,7 +11,6 @@ sorted alphabetically by first name.
 | Craig Tiller | [ctiller](https://github.com/ctiller) | C++ | [grpc](https://github.com/grpc/grpc) | Google |
 | Doug Fawley | [dfawley](https://github.com/dfawley) | Go | [grpc-go](https://github.com/grpc/grpc-go) | Google |
 | Eric Anderson | [ejona86](https://github.com/ejona86) | Java | [grpc-java](https://github.com/grpc/grpc-java) | Google |
-| Esun Kim | [veblush](https://github.com/veblush) | C++ | [grpc](https://github.com/grpc/grpc) | Google |
 | George Barnett | [glbrntt](https://github.com/glbrntt) | Swift | [grpc-swift](https://github.com/grpc/grpc-swift) | Apple |
 | James Newton-King | [JamesNK](https://github.com/JamesNK) | .Net | [grpc-dotnet](https://github.com/grpc/grpc-dotnet) | Microsoft |
 | Jung-Yu (Gina) Yeh | [ginayeh](https://github.com/ginayeh) | Go | [grpc-go](https://github.com/grpc/grpc-go) | Google |

--- a/contributors/organization_members.md
+++ b/contributors/organization_members.md
@@ -26,8 +26,6 @@ are considered Organization Members as well.
 | David Klempner | [dklempner](https://github.com/dklempner) | Google |
 | Eshita Chandwani | [eshitachandwani](https://github.com/eshitachandwani) | Google |
 | Eugene Ostroukhov | [eugeneo](https://github.com/eugeneo) | Google |
-| Guantao Liu | [guantaol](https://github.com/guantaol) | Google |
-| Hope Casey-Allen | [hcaseyal](https://github.com/hcaseyal) | Google |
 | James Ward | [jamesward](https://github.com/jamesward) | AWS |
 | John Cormie | [jdcormie](https://github.com/jdcormie) | Google |
 | Junhua Yan | [juneyan](https://github.com/juneyan) | Google |

--- a/contributors/organization_members.md
+++ b/contributors/organization_members.md
@@ -9,7 +9,6 @@ are considered Organization Members as well.
 | Name | Github Handle | Employer |
 |--|--|--|
 | Aditya Mandaleeka | [adityamandaleeka](https://github.com/adityamandaleeka) | Microsoft |
-| Akshit Patel | [ac-patel](https://github.com/ac-patel) | Google |
 | Andrew Casey | [amcasey](https://github.com/amcasey) | Microsoft |
 | Anirudh Ramachandra | [anicr7](https://github.com/anicr7) | Google |
 | April Kyle Nassi | [thisisnotapril](https://github.com/thisisnotapril) | Google |

--- a/contributors/organization_members.md
+++ b/contributors/organization_members.md
@@ -12,7 +12,6 @@ are considered Organization Members as well.
 | Andrew Casey | [amcasey](https://github.com/amcasey) | Microsoft |
 | Anirudh Ramachandra | [anicr7](https://github.com/anicr7) | Google |
 | April Kyle Nassi | [thisisnotapril](https://github.com/thisisnotapril) | Google |
-| Arjan Bal | [arjan-bal](https://github.com/arjan-bal) | Google |
 | Arjun Roy | [arjunroy](https://github.com/arjunroy) | Google |
 | Arvind Bright | [arvindbr8](https://github.com/arvindbr8) | Google |
 | Ashley Zhang | [ashzhang](https://github.com/ashzhang) | Google |
@@ -35,7 +34,6 @@ are considered Organization Members as well.
 | Michael Thomsen | [mit-mit](https://github.com/mit-mit) | Google |
 | MV Shiva Prasad | [shivaspeaks](https://github.com/shivaspeaks) | Google |
 | Nana Pang | [nanahpang](https://github.com/nanahpang) | Google |
-| Pawan Bhardwaj | [pawbhard](https://github.com/pawbhard) | Google |
 | Pau Freixes | [pfreixes](https://github.com/pfreixes) | GitHub |
 | Pranjali Saxena | [pranjali-2501](https://github.com/pranjali-2501) | Google |
 | Priyaranjan Jha | [prj2223](https://github.com/prj2223) | Google |

--- a/contributors/organization_members.md
+++ b/contributors/organization_members.md
@@ -50,6 +50,7 @@ are considered Organization Members as well.
 | Siddharth Nohria | [siddharthnohria](https://github.com/siddharthnohria) | Google |
 | Sigurd Meldgaard | [sigurdm](https://github.com/sigurdm) | Google |
 | Soheil Yeganeh | [soheilhy](https://github.com/soheilhy) | Google |
+| Sreenithi Sridharan | [sreenithi](https://github.com/sreenithi) | Google |
 | Vindhya Ningegowda | [dnvindhya](https://github.com/dnvindhya) | Google |
 | Vishal Powar | [vishalpowar](https://github.com/vishalpowar) | Google |
 | Yijie Ma | [yijiem](https://github.com/yijiem) | Google |

--- a/contributors/organization_members.md
+++ b/contributors/organization_members.md
@@ -1,0 +1,61 @@
+# Organization Members
+
+This is the authoritative listing of [Organization
+Members](../contributor_ladder.md#organization-member) within the gRPC project,
+sorted alphabetically by first name. In addition to all of the individuals
+listed here, all [Core Contributors](core_contributors.md) and [Maintainers](maintainers.md)
+are considered Organization Members as well.
+
+| Name | Github Handle | Employer |
+|--|--|--|
+| Aditya Mandaleeka | [adityamandaleeka](https://github.com/adityamandaleeka) | Microsoft |
+| Akshit Patel | [ac-patel](https://github.com/ac-patel) | Google |
+| Andrew Casey | [amcasey](https://github.com/amcasey) | Microsoft |
+| Anirudh Ramachandra | [anicr7](https://github.com/anicr7) | Google |
+| April Kyle Nassi | [thisisnotapril](https://github.com/thisisnotapril) | Google |
+| Arjan Bal | [arjan-bal](https://github.com/arjan-bal) | Google |
+| Arjun Roy | [arjunroy](https://github.com/arjunroy) | Google |
+| Arvind Bright | [arvindbr8](https://github.com/arvindbr8) | Google |
+| Ashley Zhang | [ashzhang](https://github.com/ashzhang) | Google |
+| Ashesh Vidyut | [asheshvidyut](https://github.com/asheshvidyut) | Google |
+| Benjamin Petit | [benjaminpetit](https://github.com/benjaminpetit) | Microsoft |
+| Brennan Conroy | [BrennanConroy](https://github.com/BrennanConroy) | Microsoft |
+| Brent Shaffer | [bshaffer](https://github.com/bshaffer) | Google |
+| Cathy Zhao | [cjqzhao](https://github.com/cjqzhao) | Google |
+| Daniel Gräfe | [MrMage](https://github.com/MrMage) | Timing GmbH |
+| David Fowler | [davidfowl](https://github.com/davidfowl) | Microsoft |
+| David Klempner | [dklempner](https://github.com/dklempner) | Google |
+| Eshita Chandwani | [eshitachandwani](https://github.com/eshitachandwani) | Google |
+| Eugene Ostroukhov | [eugeneo](https://github.com/eugeneo) | Google |
+| Guantao Liu | [guantaol](https://github.com/guantaol) | Google |
+| Hope Casey-Allen | [hcaseyal](https://github.com/hcaseyal) | Google |
+| James Ward | [jamesward](https://github.com/jamesward) | AWS |
+| John Cormie | [jdcormie](https://github.com/jdcormie) | Google |
+| Junhua Yan | [juneyan](https://github.com/juneyan) | Google |
+| Louis Wasserman | [lowasser](https://github.com/lowasser) | Google |
+| Marc Gravell | [mgravell](https://github.com/mgravell) | Microsoft |
+| Michael Rebello | [rebello95](https://github.com/rebello95) | Airbnb |
+| Michael Thomsen | [mit-mit](https://github.com/mit-mit) | Google |
+| MV Shiva Prasad | [shivaspeaks](https://github.com/shivaspeaks) | Google |
+| Nana Pang | [nanahpang](https://github.com/nanahpang) | Google |
+| Pawan Bhardwaj | [pawbhard](https://github.com/pawbhard) | Google |
+| Pau Freixes | [pfreixes](https://github.com/pfreixes) | GitHub |
+| Pranjali Saxena | [pranjali-2501](https://github.com/pranjali-2501) | Google |
+| Priyaranjan Jha | [prj2223](https://github.com/prj2223) | Google |
+| Ran Su | [ran-su](https://github.com/ran-su) | Google |
+| Reuben Bond | [ReubenBond](https://github.com/ReubenBond) | Microsoft |
+| Rishesh Agarwal | [rishesh007](https://github.com/rishesh007) | Google |
+| Sanskar Gupta | [Smrt-Sanskar](https://github.com/Smrt-Sanskar) | Google |
+| Sarah Zakarias | [szakarias](https://github.com/szakarias) | Google |
+| Siddharth Nohria | [siddharthnohria](https://github.com/siddharthnohria) | Google |
+| Sigurd Meldgaard | [sigurdm](https://github.com/sigurdm) | Google |
+| Soheil Yeganeh | [soheilhy](https://github.com/soheilhy) | Google |
+| Vindhya Ningegowda | [dnvindhya](https://github.com/dnvindhya) | Google |
+| Vishal Powar | [vishalpowar](https://github.com/vishalpowar) | Google |
+| Yijie Ma | [yijiem](https://github.com/yijiem) | Google |
+| Zhouyihai Ding | [zhouyihaiding](https://github.com/zhouyihaiding) | Google |
+
+## Emeritus Organization Members
+
+| Name | Github Handle | Employer |
+|--|--|--|

--- a/elections/steering-committee-election-2025.md
+++ b/elections/steering-committee-election-2025.md
@@ -1,0 +1,60 @@
+# gRPC Steering Committee Election 2025
+
+- Election Officer(s):
+  - Richard Belleville, [@gnossen](https://github.com/gnossen), [rbellevi@google.com](mailto:rbellevi@google.com)
+- Call for Nominations Begins: 2025-7-23 12:01AM Pacific
+- Call for Nominations Ends: 2025-07-30 11:59PM Pacific
+- Voting Opens: 2025-08-01 12:01AM Pacific
+- Voting Ends: 2025-08-06 11:59PM Pacific
+- Positions Take Effect: 2025-08-15 12:01AM Pacific
+- Voting form: **To be added after nominations conclude**
+- [Sample Ballot](https://forms.gle/T7bxn3sWiAb4eaUU6)
+
+## Introduction
+
+This document captures the procedures for the election of the steering committee
+serving 2025-08-15 through 2026-8-14. This election will decide the first project
+Steering Committee. As such, there is no current Steering Committee to appoint
+the Election Officers. Richard Belleville
+([@gnossen](https://github.com/gnossen)) will serve as Election Officer with his
+authority stemming from the vote ratifying the governance change present in the
+same PR as the initial commit of this document.
+
+## Nominees
+
+| Name | Github Handle | Employer | Rationale Link (Optional) |
+|--|--|--|--|
+
+
+## Procedure
+
+### Candidate Nomination
+
+[Per the governance](../governance.md#composition), anyone is eligible to
+nominate themself for the Steering Committee. Nominations will be made by
+modifying the "Nominees" table at the top of this document. If a nomination is
+made by someone other than the nominee themself, the nominee must agree to the
+nomination by commenting on the PR. A column is provided for a link to an
+optional rationale for why this nominee would make a good Steering Committee
+member.
+
+Candidate nomination will open on 2025-07-23 at 12:01AM Pacific and end on
+2025-07-30 at 11:59PM Pacific.
+
+### Voting
+
+All project [Maintainers](../contributor_ladder.md#maintainer) are eligible to
+vote, with the roster captured [here](contributors/maintainers.md). Voting will
+be conducted via Google Forms. The official form will be created after
+nominations are concluded, but a sample ballot is provided [here](https://forms.gle/T7bxn3sWiAb4eaUU6).
+
+After voting has concluded, the Election Officer(s) will tally the results with
+the IRV method and announce them by updating this document with the results and
+posting to [the grpc-io mailing list](https://groups.google.com/g/grpc-io).
+
+## Results
+
+**To be filled in after voting has concluded**
+
+| Name | Github Handle | Employer | Vote Ranking |
+|--|--|--|--|

--- a/governance.md
+++ b/governance.md
@@ -32,7 +32,7 @@ All decisions affecting gRPC, big and small, follow the same 3 steps:
 
 * Step 1: Open a pull request. Anyone can do this.
 * Step 2: Discuss the pull request. Anyone can do this.
-* Step 3: [Maintainers](contributor_ladder.md#maintainer) merge or refuse the pull request.
+* Step 3: [Maintainers](contributor_ladder.md#maintainer) accept or refuse the pull request.
 
 Exceptions to this are made for:
 
@@ -61,7 +61,7 @@ The process for handling any security vulnerabilities or concerns found in gRPC 
 
 ## Releases
 
-Details on gRPC release process and schedule can be found [here](https://github.com/grpc/grpc/blob/master/doc/grpc_release_schedule.md). Each repository has its own release process. We are in the process of making the release instructions publicly available. Only maintainers can do the releases.
+Details on gRPC release process and schedule can be found [here](https://github.com/grpc/grpc/blob/master/doc/grpc_release_schedule.md). Each repository has its own release process. We are in the process of making the release instructions publicly available. Only Maintainers have the right to do releases, but the duty may be delegated.
 
 ## Changes In Governance
 

--- a/governance.md
+++ b/governance.md
@@ -1,4 +1,4 @@
-This document describes the governance rules of the gRPC project(organization). It is meant to be followed by all the repositories in the project and the gRPC community.
+This document describes the governance rules of the gRPC project / organization. It is meant to be followed by all the repositories in the project and the gRPC community.
 
 ## Principles
 
@@ -17,9 +17,14 @@ The gRPC community abides by the CNCF [code of conduct](https://github.com/cncf/
 
 The gRPC developers and community are expected to follow the values defined in the [CNCF charter](https://www.cncf.io/about/charter/). As a member of the gRPC project, you represent the project and your fellow contributors. We value our community tremendously and we'd like to keep cultivating a friendly and collaborative environment for our contributors and users. We want everyone in the community to have [positive experiences](https://www.cncf.io/blog/2016/12/14/diversity-scholarship-series-one-software-engineers-unexpected-cloudnativecon-kubecon-experience).
 
+
 ## Decision Making And Voting
 
-gRPC is an open-source [project](https://github.com/grpc/)(organization) with an open collaboration philosophy. This means that the Github project is the source of truth for every aspect of the project, including its philosophy, design, road map, and APIs. *If it's part of the project, it's in the repos. If it's in the repos, it's part of the project.*
+gRPC is an open-source [project / organization](https://github.com/grpc/) with an
+open collaboration philosophy. This means that the Github project is the source
+of truth for every aspect of the project, including its philosophy, design, road
+map, and APIs. *If it's part of the project, it's in the repos. If it's in the
+repos, it's part of the project.*
 
 As a result, all decisions can be expressed as changes to the repository. An implementation change is a change to the source code. An API change is a change to the API specification. A philosophy change is a change to the philosophy manifesto, and so on.
 
@@ -27,43 +32,28 @@ All decisions affecting gRPC, big and small, follow the same 3 steps:
 
 * Step 1: Open a pull request. Anyone can do this.
 * Step 2: Discuss the pull request. Anyone can do this.
-* Step 3: Maintainers merge or refuse the pull request.
+* Step 3: [Maintainers](contributor_ladder.md#maintainer) merge or refuse the pull request.
 
-In general, we prefer that technical issues and maintainer membership are amicably worked out between the persons involved. If a dispute cannot be decided independently, the maintainers can be called in to resolve the issue by voting. The same PR can be used or a separate PR can be opened in the concerned repository for voting. The title of a PR related to voting should be prefixed with “[vote]”. Such PRs should remain open for a minimum of two weeks unless a decision has been reached sooner. A formal voting on the PR is not required if majority of the maintainers have already agreed in other forums or meetings. In such cases, a detailed comment must be added by a maintainer before approving or rejecting the PR. In such a case, only an existing maintainer can ask for a formal vote to challenge the decision. Each maintainer can cast a maximum of one vote regardless of the number of repositories the maintainer is listed in. A simple majority is required to approve the PR. Only the maintainers listed in MAINTAINERS.md file of the concerned repository may vote on the PR. For cross-repository issues, the PR can be opened in [grpc-community](https://github.com/grpc/grpc-community) or [proposal](https://github.com/grpc/proposal) repositories. The list of maintainers in these repositories is a superset of the list of maintainers in all other repositories in the gRPC Github organization. For ease of maintenance only a few senior maintainers will have write access to grpc-community and proposal repositories.
+Exceptions to this are made for:
+
+- the election of the steering committee, the details of which are in this document
+- changes to the contributor ladder status of an individual, the requirements for which are outlined in [the contributor ladder](contributor_ladder.md)
+
+In general, we prefer that technical issues are amicably worked out between the persons involved. If a dispute cannot be decided independently, the Maintainers can be called in to resolve the issue by voting. The same PR can be used or a separate PR can be opened in the concerned repository for voting. The title of a PR related to voting should be prefixed with “[vote]”. Such PRs should remain open for a minimum of two weeks unless a decision has been reached sooner. A formal vote on the PR is not required if a majority of the maintainers have already agreed in other forums or meetings. In such cases, a detailed comment must be added by a Maintainer before approving or rejecting the PR. In such a case, only an existing Maintainer can ask for a formal vote to challenge the decision. Each Maintainer can cast a maximum of one vote regardless of the number of repositories the maintainer is listed in. A simple majority is required to approve the PR. Only the [Maintainers](contributor_ladder.md#maintainer) associated with the concerned repository (as documented in [maintainers.md](contributors/maintainers.md)) may vote on the PR. For cross-repository issues, the PR can be opened in [grpc-community](https://github.com/grpc/grpc-community) or [proposal](https://github.com/grpc/proposal) repositories. In these cross-repository cases, all [Maintainers](contributor_ladder.md#maintainer) are eligible to vote. The official roster of all Maintainers will be kept up to date in this repo in the [contributors/maintainers.md](contributors/maintainers.md) file. [The Steering Committee](#steering-committee) will have write access to these two repositories, but must use the official voting process outlined above for any changes to them.
 
 ## The gRFC Process
 
-We use [gRFCs](https://github.com/grpc/proposal/blob/master/README.md) for any substantial changes to gRPC. This process involves an upfront design that will provide increased visibility to the community. If you're considering a PR that will bring in a new feature across several languages, affect how gRPC is implemented, or may be a breaking change; then you should start with a gRFC. We've got the process documented in [proposal](https://github.com/grpc/proposal) repository and have a [template](https://github.com/grpc/proposal/blob/master/GRFC-TEMPLATE.md) for you to get started.
+We use [gRFCs](https://github.com/grpc/proposal/blob/master/README.md) for any substantial changes to gRPC. This process involves an upfront design that will provide increased visibility to the community. If you're considering a PR that will bring in a new feature across several languages, affect how gRPC is implemented, or may be a breaking change; then you must start with a gRFC. The process is documented in the [proposal](https://github.com/grpc/proposal) repository and a template is provided [here](https://github.com/grpc/proposal/blob/master/GRFC-TEMPLATE.md).
 
 ## How To Contribute
 
-See the general guidelines [here](https://github.com/grpc/grpc-community/blob/master/CONTRIBUTING.md) on how to contribute to gRPC project. If you want to become a maintainer see the section below.
-
-## How To Become A Maintainer
-
-Maintainers (also known as Committers) are first and foremost contributors that have shown they are committed to the long term success of a project. Becoming a maintainer is not required for almost all contributions. In addition to submitting PRs, a maintainer can:
-* Triage issues and PRs filed in the repo and assign appropriate labels and reviewers.
-* Trigger tests and merge PRs once other checks and criteria pass.
-* Cast a vote on issues requiring voting.
-
-Contributors wanting to become maintainers are expected to:
-* Be involved in contributing code, pull request review, triage of issues and addressing user questions in one or more forums such as [Github](https://github.com/grpc), [grpcio](https://groups.google.com/forum/#!forum/grpc-io) mailing list, [Stackoverflow](https://stackoverflow.com/search?q=grpc) and [Gitter](https://gitter.im/grpc/grpc).
-* Maintain sustained contribution to the gRPC project and spend a reasonable amount of time on it.
-* Show deep understanding of the areas contributed to, and good consideration of various reliability, usability, backward compatibility and performance requirements.
-
-These are a few ways to become a maintainer:
-* Create a PR adding yourself to MAINTAINERS.md in the appropriate repository. Before doing so it is a good practice to socialize with some existing maintainers to get a good feel for whether you meet the above criteria. A simple majority vote is required to approve the PR. See above for the voting process.
-* Current maintainers may nominate a contributor and confer maintainer status. A formal voting on the PR is not required if majority maintainers have already agreed in other forums or meetings.
-
-Please note that in order to be part of the organization, your Github account needs to have [two factor security](https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/) enabled.
-
-## Losing Maintainer Status
-
-If a maintainer is no longer interested or cannot perform the maintainer duties listed above, they should volunteer to be moved to emeritus status. If possible, try to complete your work or help find someone to pick up your work before stepping down. If a maintainer has stopped contributing for a reasonable amount of time, other maintainers may propose to move such maintainers to emeritus list without prior notice. The PR for a such as change would serve as the notice. Such a PR should have @mention of the maintainer in question and should remain open for at least a period of two weeks. Any disagreements will be resolved by a vote of the maintainers per the voting process above.
+See the general guidelines
+[here](https://github.com/grpc/grpc-community/blob/master/CONTRIBUTING.md) on
+how to contribute to the gRPC project.
 
 ## Adding New Repositories
 
-Similar to adding maintainers, new repositories can be added to gRPC GitHub organization as long as they adhere to the CNCF [charter](https://www.cncf.io/about/charter/) and gRPC governance guidelines. After a project proposal has been announced on a public forum (GitHub issue or mailing list), the existing maintainers have two weeks to discuss the new project, raise objections and cast their vote. Projects must be approved by a majority vote following the process described above. If a project is approved, a maintainer will add the project to the gRPC GitHub organization, and make an announcement on a public forum.
+New repositories can be added to gRPC GitHub organization as long as they adhere to the CNCF [charter](https://www.cncf.io/about/charter/) and gRPC governance guidelines. After a project proposal has been announced on a public forum (GitHub issue or mailing list), the existing Maintainers have two weeks to discuss the new project, raise objections and cast their vote. Projects must be approved by a majority vote following the process described above. If a project is approved, a Maintainer will add the project to the gRPC GitHub organization, and make an announcement on a public forum.
 
 ## Handling Security Vulnerabilities
 
@@ -77,4 +67,131 @@ Details on gRPC release process and schedule can be found [here](https://github.
 
 Any change in this document must go through the voting process described above.
 
+## Steering Committee
 
+The following responsibilities and powers belong to the Steering Committee:
+
+* Define, evolve, and defend the vision, mission and the values of the project.
+* Request funds and other support from the CNCF (e.g. marketing, press, etc.)
+* Coordinate with the CNCF regarding usage of the gRPC brand and deciding
+  project scope, core requirements, and conformance, as well as how that brand
+  can be used in relation to other efforts or vendors.
+
+### Committee Meetings
+
+The Steering Committee will meet once per quarter, or as needed.
+Meetings are held online, and are public by default.
+
+Given the private nature of some of these discussions (e.g. privacy, private
+emails to the committee, code of conduct violations, escalations, disputes
+between members, security reports, etc.) some meetings may be held in private.
+
+Meeting notes will be made available to members of the
+[grpc-io mailing list](https://groups.google.com/g/grpc-io).
+Public meetings will be recorded and the recordings made available publicly.
+
+### Committee members
+
+Seats on the Steering Committee are held by an individual, not by their
+employer.
+
+The current membership of the committee is (listed alphabetically by
+first name):
+
+| &nbsp;                                                         | Member           | Organization |
+| -------------------------------------------------------------- | ---------------- | ------------ |
+** TO BE FILLED IN AFTER THE FIRST ELECTION **
+
+
+### Decision process
+
+The Steering Committee desires to always reach consensus.
+
+Decisions requiring a vote include: issuing written policy, amending existing
+written policy, all spending, hiring, and contracting, official responses to
+the CNCF, or any other decisions that at least two of the members
+present decide require a vote.
+
+Decisions are made in meetings when a quorum of more than half of the members
+are present (and all members have been informed of the meeting), and may pass
+with more than half the members of the committee supporting it.
+
+### Getting in touch
+
+There are two ways to raise issues to the steering committee for decision:
+
+1. Emailing the Steering Committee at
+   [grpc-steering@googlegroups.com](mailto:grpc-steering@googlegroups.com).
+   This is a private discussion list to which all members of the committee have
+   access.
+2. Open an issue on
+[grpc/grpc-community](https://github.com/grpc/grpc-community) and indicate that
+you would like attention from the steering committee.
+
+### Composition
+
+The steering committee has 7 seats. These seats are
+open to anyone. While anyone may nominate anyone else, the nominee must
+provide consent and attest their commitment to the responsibilities that the
+position entails.
+
+### Election Procedure
+
+#### Timeline
+
+Steering Committee elections are held annually and terms are a year in length.
+Two weeks or more before the election, the Steering Committee will appoint
+Election Officer(s) (see below).  One week or more before the election, the
+Election Officer(s) will issue a call for nominations. One day before the
+election, the call for nominations will be closed. The election will be open
+for voting not less than one week and not more than four. The results of the
+election will be announced within one week of closing the election. New
+Steering Committee members will take office on August 15th each year.
+
+#### Election Officer(s)
+
+Six weeks or more before the election, the Steering Committee will appoint
+between one and three Election Officer(s) to administer the election. Elections
+Officers will be community members in good standing who are eligible to
+vote, are not running for Steering in that election, who are not currently part
+of the Steering Committee and can make a public promise of impartiality. They
+will be responsible for:
+
+- Making all announcements associated with the election
+- Preparing and distributing electronic ballots
+- Assisting candidates in preparing and sharing statements
+- Tallying voting results according to the rules in this charter
+
+#### Eligibility to Vote
+
+gRPC project [Maintainers](contributor_ladder.md#maintainer), as defined by
+[the contributor ladder](contributor_ladder.md), are eligible to vote. The
+official list of Maintainers will be kept up to date in this repository in
+[contributors/maintainers.md](contributors/maintainers.md).
+
+Anyone holding status as a [Maintainer](contributor_ladder.md#maintainer) at
+any any point while the voting is open will be able to cast a vote. The
+Election Officer(s) will make available a voter's guide within this repository.
+
+#### Voting Procedure
+
+Elections will be held using a time-limited
+[Condorcet](https://en.wikipedia.org/wiki/Condorcet_method) ranking using the
+IRV method. Voters will be able to rank the candidates from most to least
+preferred, possibly omitting candidates. The top vote-getters will be elected to
+the open seats. Any ties will be resolved by a revote with losing candidates from
+the previous round removed.
+
+### Vacancies
+
+In the event of a resignation or other loss of an elected steering committee
+member, the candidate with the next most votes from the previous election will
+be offered the seat. This process will continue until the seat is filled.
+
+In case this fails to fill the seat, a special election for that position will
+be held as soon as possible, unless the regular steering committee election is
+less than 7 weeks away. Eligible voters from the most recent election will vote
+in the special election. Eligibility will not be redetermined at the time of the
+special election. Any replacement steering committee member will serve out the
+remainder of the term for the person they are replacing, regardless of the
+length of that remainder.


### PR DESCRIPTION
This PR amends our project governance to bring us in line with the majority of CNCF projects. In particular, it:

- Adds a Steering Committee with clearly defined election procedures, open to individuals regardless of their employer
- Introduces a contributor ladder clearly defining how an individual / employee can go from zero presence in the project to a maintainer with full voting rights.

The added text in this PR is largely pulled from CNCF governance templates.

This PR bootstraps into this new process by:

- Moving existing project contributors to an appropriate rung within the new contributor ladder based on discussions with senior gRPC project members.
- Outlining the details of the election of the first Steering Committee.