### PR TITLE
Revert "nominate_ashish_srivastava"

### DIFF
--- a/elections/steering-committee-election-2025.md
+++ b/elections/steering-committee-election-2025.md
@@ -31,7 +31,6 @@ same PR as the initial commit of this document.
 | Kevin Nilson | [kevinnilson](https://github.com/kevinnilson) | Google | |
 | Craig Tiller | [ctiller](https://github.com/ctiller) | Google | |
 | Nupur Kothari | [nupurkot](https://github.com/nupurkot) | Google | |
-| Ashish Srivastava | [ashishksrivastava](https://github.com/ashishksrivastava) | Google | |
 
 ## Procedure
 


### PR DESCRIPTION
This reverts a direct push to the `main` branch.  Branch protection will be added to avoid this in the future.

I've informed @pawbhard that he'll need to create a PR and get a comment from @ashishksrivastava accepting the nomination like in the other nominations ([example](https://github.com/grpc/grpc-community/pull/31), [example](https://github.com/grpc/grpc-community/pull/28))