### PR TITLE
Nominate Sergii Tkachenko for Maintainer

### DIFF
--- a/contributors/core_contributors.md
+++ b/contributors/core_contributors.md
@@ -30,7 +30,6 @@ as well.
 | Patrice Chalin | [chalin](https://github.com/chalin) | grpc.io | [grpc.io](https://github.com/grpc/grpc.io) | CNCF |
 | Paulo Castello da Costa | [paulosjca](https://github.com/paulosjca) | Benchmarking | [test-infra](https://github.com/grpc/test-infra) | Google |
 | Pawan Bhardwaj | [pawbhard](https://github.com/pawbhard) | Core/C++ | [grpc](https://github.com/grpc/grpc) | Google |
-| Sergii Tkachenko | [sergiitk](https://github.com/sergiitk) | Python, xDS Interop | [grpc](https://github.com/grpc/grpc), [psm-interop](https://github.com/grpc/psm-interop) | Google |
 | Stanley Cheung | [stanley-cheung](https://github.com/stanley-cheung) | PHP | [grpc](https://github.com/grpc/grpc) | Google | 
 | Terry Wilson | [temawi](https://github.com/temawi) | Android | [grpc-java](https://github.com/grpc/grpc-java) | Google | 
 | Tanvi Jagtap | [tanvi-jagtap](https://github.com/tanvi-jagtap) | Core/C++ | [grpc](https://github.com/grpc/grpc) | Google | 

--- a/contributors/maintainers.md
+++ b/contributors/maintainers.md
@@ -19,6 +19,7 @@ sorted alphabetically by first name.
 | Michael Lumish | [murgatroid99](https://github.com/murgatroid99) | Node.js | [grpc-node](https://github.com/grpc/grpc-node) | Google | 
 | Nupur Kothari | [nupurkot](https://github.com/nupurkot) | C++, Java, Python | [grpc](https://github.com/grpc/grpc), [grpc-java](https://github.com/grpc/grpc-java) | Google | 
 | Richard Belleville | [gnossen](https://github.com/gnossen) | Python | [grpc](https://github.com/grpc/grpc) | Google |
+| Sergii Tkachenko | [sergiitk](https://github.com/sergiitk) | Python, xDS Interop | [grpc](https://github.com/grpc/grpc), [psm-interop](https://github.com/grpc/psm-interop) | Google |
 
 ## Emeritus Maintainers
 


### PR DESCRIPTION
I'd like to nominate Sergii to Maintainer based on his exemplary performance as the new Tech Lead for gRPC Python. Sergii has demonstrated both technical mastery and impressive personal dedication to the project.