### PR TITLE
Fix typo in GitHub and StackOverflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-If you are interested in contributing to the gRPC project, below are some general guidelines that apply to all the repositories in gRPC Github organization. Please read the additional instructions in CONTRIBUTING.md file of the concerned repository.
+If you are interested in contributing to the gRPC project, below are some general guidelines that apply to all the repositories in gRPC GitHub organization. Please read the additional instructions in CONTRIBUTING.md file of the concerned repository.
 
 ## Before You Contribute
 
@@ -11,10 +11,10 @@ In order to protect both you and the gRPC project, you will need to sign the CNC
 
 ## Communication
 
-Trivial changes and small bug fixes do not need prior communication. You can just submit a PR with minimum details. For larger PRs, we ask that before contributing, please make the effort to coordinate with the maintainers of the project via a Github issue or via [grpcio](https://groups.google.com/forum/#!forum/grpc-io) mailing list. This will prevent you from doing extra or redundant work that may or may not be merged.
+Trivial changes and small bug fixes do not need prior communication. You can just submit a PR with minimum details. For larger PRs, we ask that before contributing, please make the effort to coordinate with the maintainers of the project via a GitHub issue or via [grpcio](https://groups.google.com/forum/#!forum/grpc-io) mailing list. This will prevent you from doing extra or redundant work that may or may not be merged.
 
 ## Have Questions?
-It is best to ask questions on forums other than Github repos. Github repos are for filing issues and submitting PRs. You have a higher chance of getting help from the community if you ask your questions on [grpcio](https://groups.google.com/forum/#!forum/grpc-io) mailing list or [Stackoverflow](https://stackoverflow.com/).
+It is best to ask questions on forums other than GitHub repos. GitHub repos are for filing issues and submitting PRs. You have a higher chance of getting help from the community if you ask your questions on [grpcio](https://groups.google.com/forum/#!forum/grpc-io) mailing list or [StackOverflow](https://stackoverflow.com/).
 
 ## Guidelines For Pull Requests
 
@@ -29,5 +29,5 @@ How to get your contributions merged smoothly and quickly.
 * Maintain clean commit history and use meaningful commit messages. PRs with messy commit history are difficult to review and won't be merged. Use rebase -i upstream/master to curate your commit history and/or to bring in latest changes from master but avoid rebasing in the middle of a code review.
 * Keep your PR up to date with upstream/master. If there are merge conflicts, we can't really merge your change.
 
-Above are general guidelines that apply to all the repositories in gRPC Github organization. Please read the additional instructions in CONTRIBUTING.md file of the concerned repository.
+Above are general guidelines that apply to all the repositories in gRPC GitHub organization. Please read the additional instructions in CONTRIBUTING.md file of the concerned repository.
 

--- a/contributor_ladder.md
+++ b/contributor_ladder.md
@@ -198,7 +198,7 @@ Process of becoming a maintainer:
 It is important for contributors to remain active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a loss of trust in the project.
 
 * Inactivity is measured by:
-    * Periods of no contributions for longer than 6 months, including Github comments, PRs, and issues.
+    * Periods of no contributions for longer than 6 months, including GitHub comments, PRs, and issues.
     * Periods of no communication for longer than 6 months, including emails, messages, and attendance at project meetings.
 * Consequences of being inactive include:
     * Involuntary removal or demotion

--- a/contributors/core_contributors.md
+++ b/contributors/core_contributors.md
@@ -8,7 +8,7 @@ listed here, all [Maintainers](maintainers.md) are considered Core Contributors
 as well.
 
 
-| Name | Github Handle | Area(s) of Expertise | Repo(s) | Employer | 
+| Name | GitHub Handle | Area(s) of Expertise | Repo(s) | Employer | 
 |--|--|--|--|--|
 | Aananth V | [aananthv](https://github.com/aananthv) | Core/C++ | [grpc](https://github.com/grpc/grpc) | Google |
 | Adam Heller | [drfloob](https://github.com/drfloob) | Core/C++, EventEngine | [grpc](https://github.com/grpc/grpc) | Google |
@@ -40,5 +40,5 @@ as well.
 
 ## Emeritus Core Contributors
 
-| Name | Github Handle | Area(s) of Expertise | Repo(s) | Employer | 
+| Name | GitHub Handle | Area(s) of Expertise | Repo(s) | Employer | 
 |--|--|--|--|--|

--- a/contributors/maintainers.md
+++ b/contributors/maintainers.md
@@ -5,7 +5,7 @@ This is the authoritative listing of
 sorted alphabetically by first name.
 
 
-| Name | Github Handle | Area(s) of Expertise | Repo(s) | Employer | 
+| Name | GitHub Handle | Area(s) of Expertise | Repo(s) | Employer | 
 |--|--|--|--|--|
 | Antoine Tollenaere | [atollena](https://github.com/atollena) | Go | [grpc-go](https://github.com/grpc/grpc-go) | Datadog |
 | Craig Tiller | [ctiller](https://github.com/ctiller) | C++ | [grpc](https://github.com/grpc/grpc) | Google |
@@ -23,5 +23,5 @@ sorted alphabetically by first name.
 
 ## Emeritus Maintainers
 
-| Name | Github Handle | Area(s) of Expertise | Repo(s) | Employer | 
+| Name | GitHub Handle | Area(s) of Expertise | Repo(s) | Employer | 
 |--|--|--|--|--|

--- a/contributors/organization_members.md
+++ b/contributors/organization_members.md
@@ -6,7 +6,7 @@ sorted alphabetically by first name. In addition to all of the individuals
 listed here, all [Core Contributors](core_contributors.md) and [Maintainers](maintainers.md)
 are considered Organization Members as well.
 
-| Name | Github Handle | Employer |
+| Name | GitHub Handle | Employer |
 |--|--|--|
 | Abhishek Agrawal | [AgraVator](https://github.com/AgraVator) | Google |
 | Aditya Mandaleeka | [adityamandaleeka](https://github.com/adityamandaleeka) | Microsoft |
@@ -54,5 +54,5 @@ are considered Organization Members as well.
 
 ## Emeritus Organization Members
 
-| Name | Github Handle | Employer |
+| Name | GitHub Handle | Employer |
 |--|--|--|

--- a/elections/steering-committee-election-2025.md
+++ b/elections/steering-committee-election-2025.md
@@ -22,7 +22,7 @@ same PR as the initial commit of this document.
 
 ## Nominees
 
-| Name | Github Handle | Employer | Rationale Link (Optional) |
+| Name | GitHub Handle | Employer | Rationale Link (Optional) |
 |--|--|--|--|
 | Mark Roth | [markdroth](https://github.com/markdroth) | Google | |
 | Antoine Tollenaere | [atollena](https://github.com/atollena) | Datadog | |

--- a/governance.md
+++ b/governance.md
@@ -21,7 +21,7 @@ The gRPC developers and community are expected to follow the values defined in t
 ## Decision Making And Voting
 
 gRPC is an open-source [project / organization](https://github.com/grpc/) with an
-open collaboration philosophy. This means that the Github project is the source
+open collaboration philosophy. This means that the GitHub project is the source
 of truth for every aspect of the project, including its philosophy, design, road
 map, and APIs. *If it's part of the project, it's in the repos. If it's in the
 repos, it's part of the project.*


### PR DESCRIPTION
`Github` -> `GitHub`

`Stackoverflow` -> `StackOverflow`